### PR TITLE
Increase/contract size

### DIFF
--- a/internal/params/protocol_params.go
+++ b/internal/params/protocol_params.go
@@ -151,7 +151,7 @@ const (
 	CreateBySelfdestructGas uint64 = 25000
 
 	// MaxCodeSize ...
-	MaxCodeSize = 24576 // Maximum bytecode to permit for a contract
+	MaxCodeSize = 34576 // Maximum bytecode to permit for a contract
 
 	// Precompiled contract gas prices
 


### PR DESCRIPTION
## Issue

This PR increases the max contract size from 24,576 to 34,576 bytes on the POSI Chain, making it more suitable for deploying larger and more complex smart contracts for FuturX and DPTP.

## Test

N/A

## Operational Checklist

1. **Does this PR introduce backward-incompatible changes to the on-disk data structure and/or the over-the-wire protocol?**. (If no, skip to question 8.)

    **NO**

2. **Describe the migration plan.**. For each flag epoch, describe what changes take place at the flag epoch, the anticipated interactions between upgraded/non-upgraded nodes, and any special operational considerations for the migration.

The migration plan consists of first deploying the proposed change on Testnet, where it will be tested extensively. Once validated, the change will go through a vote on mainnet. If the vote is successful, the change will be implemented on mainnet.

3. **Describe how the plan was tested.**

The plan will be tested by deploying the change on Testnet and monitoring its performance. This will involve checking for potential issues, compatibility with existing contracts, and overall stability.

5. **How much minimum baking period after the last flag epoch should we allow on Pangaea before promotion onto mainnet?**

We should allow at least 1-2 weeks of baking period on Testnet to ensure the stability and performance of the change.

7. **What are the planned flag epoch numbers and their ETAs on mainnet?**


9. **What should node operators know about this planned change?**

Node operators should be aware that the proposed change aims to increase the max contract size from 24,576 to 34,576 bytes. This will allow for the deployment of larger and more complex smart contracts on POSI Chain. The change will first be tested on Testnet and, if successful, will go through a vote, if passed, all node operators, need to upgrade to the new version.

11. **Does this PR introduce backward-incompatible changes *NOT* related to on-disk data structure and/or over-the-wire protocol?** (If no, continue to question 10.)

    **NO**

12. **Does the existing `node.sh` continue to work with this change?**

Yes, the existing node.sh will continue to work with this change.

14. **What should node operators know about this change?**

15. **Does this PR introduce significant changes to the operational requirements of the node software, such as >20% increase in CPU, memory, and/or disk usage?**

Wait for test result

## TODO

